### PR TITLE
correct misspelled vaules filename.

### DIFF
--- a/deploy/helmsman-dsf.yaml
+++ b/deploy/helmsman-dsf.yaml
@@ -14,7 +14,7 @@ apps:
     enabled: true
     chart: praqma/jira
     version: 0.4.3
-    valuesFile: jira-vaules.yaml
+    valuesFile: jira-values.yaml
   
   jira-postgres:
     namespace: jira


### PR DESCRIPTION
In deploy/helmsman-dsf.yaml, the values file was spelled "jira-vaules.yaml", while it is actually spelled "jira-values.yaml".